### PR TITLE
Add branch compare cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,23 @@ command is slow because it generates and then loads everything.
   -h, --help                       Show this message.
 ```
 
+### brew branch-compare
+
+```
+Usage: brew branch-compare [options] -- command
+
+Runs a brew command on both the current branch and the main branch and then
+diffs the output of both commands. This helps with debugging and assurance
+testing when making changes to important commands.
+
+Example: brew branch-compare -- deps --installed
+
+  -d, --debug                      Display any debugging information.
+  -q, --quiet                      Make some output more quiet.
+  -v, --verbose                    Make some output more verbose.
+  -h, --help                       Show this message.
+```
+
 ### brew kitchen-sink
 
 ```

--- a/cmd/api-readall-test.rb
+++ b/cmd/api-readall-test.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-# We will generate the API JSON locally so we don't need the API here.
-ENV["HOMEBREW_NO_INSTALL_FROM_API"] = "1"
-
 require "cli/parser"
 require_relative "../lib/hd_utils"
 

--- a/cmd/branch-compare.rb
+++ b/cmd/branch-compare.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "cli/parser"
+require "tempfile"
+
+module Homebrew
+  def self.branch_compare_args
+    Homebrew::CLI::Parser.new do
+      usage_banner "`branch-compare` [<options>] -- command"
+      description <<~EOS
+        Runs a brew command on both the current branch and the main branch
+        and then diffs the output of both commands. This helps with debugging
+        and assurance testing when making changes to important commands.
+
+        Example: `brew branch-compare -- deps --installed`
+      EOS
+
+      named_args :command, min: 1
+    end
+  end
+
+  def self.branch_compare
+    args = branch_compare_args.parse
+    command = args.named
+
+    if command.first == "brew"
+      odie "`brew` is not needed at the beginning of the subcommand"
+    elsif !`brew commands --quiet`.lines(chomp: true).include?(command.first)
+      odie "Unknown command: `brew #{command.first}`"
+    end
+
+    Dir.chdir(HOMEBREW_REPOSITORY) do
+      master_branch = "master"
+      current_branch = `git branch --show-current`.strip
+
+      if master_branch == current_branch
+        odie "Current branch is the master branch. Switch to a feature branch and try again."
+      end
+      
+      output_files = [
+        master_branch,
+        current_branch,
+      ].map do |branch|
+        unless system("git checkout #{branch} #{"&>/dev/null" if args.quiet?}")
+          odie "error checking out #{branch} branch"
+        end
+        
+        outfile = Tempfile.new(branch)
+        IO.popen({"HOMEBREW_NO_AUTO_UPDATE" => "1"}, [HOMEBREW_BREW_FILE, *command]) do |pipe|
+          outfile.write pipe.read
+        end
+        outfile.close
+
+        unless $CHILD_STATUS.exitstatus.zero?
+          odie "failure on #{branch} branch"
+        end
+
+        outfile
+      end
+
+      master_branch_outfile, current_branch_outfile = output_files.map(&:path)
+
+      unless system("diff", master_branch_outfile, current_branch_outfile)
+        Homebrew.failed = true
+      end
+
+      output_files.each(&:unlink)
+    ensure
+      # Return user to the correct branch in the event of a failure
+      system("git checkout #{current_branch} &> /dev/null")
+    end
+  end
+end


### PR DESCRIPTION
Resolves #5.

It essentially requires you to be on a different branch but then allows you to compare a subcommands output between branches and then returns you to the original branch.

Limitations:
- Doesn't support comparing two random branches. Always compares the current branch to master.
- Doesn't allow you to pass environment variables to the subcommand.
- Slow (not sure there's much we can do about that)