### PR TITLE
Use git-diff in branch-compare cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ testing when making changes to important commands.
 
 Example: brew branch-compare -- deps --installed
 
+      --word-diff                  Show word diff instead of default line diff.
   -d, --debug                      Display any debugging information.
   -q, --quiet                      Make some output more quiet.
   -v, --verbose                    Make some output more verbose.

--- a/cmd/branch-compare.rb
+++ b/cmd/branch-compare.rb
@@ -15,6 +15,8 @@ module Homebrew
         Example: `brew branch-compare -- deps --installed`
       EOS
 
+      switch "--word-diff", description: "Show word diff instead of default line diff."
+
       named_args :command, min: 1
     end
   end
@@ -60,7 +62,13 @@ module Homebrew
 
       master_branch_outfile, current_branch_outfile = output_files.map(&:path)
 
-      unless system("diff", master_branch_outfile, current_branch_outfile)
+      diff_command = %w[git diff --no-index]
+      diff_command << "--word-diff" if args.word_diff?
+      diff_command << "--no-color" if ENV["HOMEBREW_NO_COLOR"]
+      diff_command << master_branch_outfile
+      diff_command << current_branch_outfile
+
+      unless system(*diff_command)
         Homebrew.failed = true
       end
 


### PR DESCRIPTION
This provides better portability because we can be sure that any brew user has git installed locally. It also gives us access to colored output and word diff.