### PR TITLE
Add service diff cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,23 @@ Example: brew branch-compare --quiet -- deps --installed
   -v, --verbose                    Make some output more verbose.
   -h, --help                       Show this message.
 ```
+
+### brew service-diff
+
+```
+Usage: brew service-diff [options]
+
+Compare the service file generation on macOS and Linux before and after changes
+to brew. This helps with debugging and assurance testing when making changes to
+the brew services DSL.
+
+Note: By default it compares all formula files with services defined.
+
+      --formula                    Run the diff on only one formula.
+      --tap                        Run the diff on only one tap.
+      --word-diff                  Show word diff instead of default line diff.
+  -d, --debug                      Display any debugging information.
+  -q, --quiet                      Make some output more quiet.
+  -v, --verbose                    Make some output more verbose.
+  -h, --help                       Show this message.
+```

--- a/cmd/branch-compare.rb
+++ b/cmd/branch-compare.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "cli/parser"
-require "tempfile"
+require_relative "../lib/hd_utils"
 
 module Homebrew
   def self.branch_compare_args
@@ -27,64 +27,12 @@ module Homebrew
     args = branch_compare_args.parse
     command = args.named
 
-    if command.first == "brew"
-      odie "`brew` is not needed at the beginning of the subcommand"
-    elsif !`brew commands --quiet`.lines(chomp: true).include?(command.first)
-      odie "Unknown command: `brew #{command.first}`"
-    end
-
-    quiet_options = args.quiet? ? { out: File::NULL, err: File::NULL } : {}
-    spawn_options = args.with_stderr? ? { err: [:child, :out] } : {}
-
-    Dir.chdir(HOMEBREW_REPOSITORY) do
-      master_branch = "master"
-      current_branch = `git branch --show-current`.strip
-
-      if master_branch == current_branch
-        odie "Current branch is the master branch. Switch to a feature branch and try again."
-      end
-      
-      output_files = [
-        master_branch,
-        current_branch,
-      ].map do |branch|
-        unless system("git checkout #{branch}", **quiet_options)
-          odie "error checking out #{branch} branch"
-        end
-        
-        outfile = Tempfile.new(branch)
-        IO.popen(
-          {"HOMEBREW_NO_AUTO_UPDATE" => "1"},
-          [HOMEBREW_BREW_FILE, *command],
-          **spawn_options
-        ) do |pipe|
-          outfile.write pipe.read
-        end
-        outfile.close
-
-        if !args.ignore_errors? && !$CHILD_STATUS.exitstatus.zero?
-          odie "failure on #{branch} branch"
-        end
-
-        outfile
-      end
-
-      master_branch_outfile, current_branch_outfile = output_files.map(&:path)
-
-      diff_command = %w[git diff --no-index]
-      diff_command << "--word-diff" if args.word_diff?
-      diff_command << "--no-color" if ENV["HOMEBREW_NO_COLOR"]
-      diff_command << master_branch_outfile
-      diff_command << current_branch_outfile
-
-      unless system(*diff_command)
-        Homebrew.failed = true
-      end
-
-      output_files.each(&:unlink)
-    ensure
-      # Return user to the correct branch in the event of a failure
-      system("git checkout #{current_branch}", out: File::NULL, err: File::NULL)
-    end
+    HDUtils::BranchDiff.run_command(
+      command,
+      quiet: args.quiet?,
+      word_diff: args.word_diff?,
+      with_stderr: args.with_stderr?,
+      ignore_errors: args.ignore_errors?
+    )
   end
 end

--- a/cmd/branch-compare.rb
+++ b/cmd/branch-compare.rb
@@ -27,7 +27,7 @@ module Homebrew
     args = branch_compare_args.parse
     command = args.named
 
-    HDUtils::BranchDiff.run_command(
+    HDUtils::BranchDiff.diff_output(
       command,
       quiet: args.quiet?,
       word_diff: args.word_diff?,

--- a/cmd/service-diff.rb
+++ b/cmd/service-diff.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "cli/parser"
+require_relative "../lib/hd_utils"
+
+module Homebrew
+  def self.service_diff_args
+    Homebrew::CLI::Parser.new do
+      usage_banner "`service-diff` [<options>]"
+      description <<~EOS
+        Compare the service file generation on macOS and Linux before
+        and after changes to brew. This helps with debugging and assurance
+        testing when making changes to the `brew services` DSL.
+
+        Note: By default it compares all formula files with services defined.
+      EOS
+
+      flag "--formula=", description: "Run the diff on only one formula."
+      flag "--tap=", description: "Run the diff on only one tap."
+      switch "--word-diff", description: "Show word diff instead of default line diff."
+
+      conflicts "--tap=", "--formula="
+    end
+  end
+
+  def self.service_diff
+    args = service_diff_args.parse
+
+    script_path = File.expand_path("../scripts/service_diff.rb", __dir__)
+
+    script_args =
+      if args.tap
+        ["tap", args.tap]
+      elsif args.formula
+        ["formula", args.formula]
+      else
+        ["all"]
+      end
+
+    HDUtils::BranchDiff.run_script(
+      script_path,
+      *script_args,
+      quiet: args.quiet?,
+      word_diff: args.word_diff?
+    )
+  end
+end

--- a/cmd/service-diff.rb
+++ b/cmd/service-diff.rb
@@ -26,7 +26,8 @@ module Homebrew
   def self.service_diff
     args = service_diff_args.parse
 
-    script_path = File.expand_path("../scripts/service_diff.rb", __dir__)
+    script_path = File.expand_path("../lib/diff-scripts/service_diff.rb", __dir__)
+    odie "Script #{script_path} doesn't exist!" unless File.exist?(script_path)
 
     script_args =
       if args.tap
@@ -37,9 +38,10 @@ module Homebrew
         ["all"]
       end
 
-    HDUtils::BranchDiff.run_script(
-      script_path,
-      *script_args,
+    command = [HOMEBREW_BREW_FILE, "ruby", "--", script_path, *script_args]
+
+    HDUtils::BranchDiff.diff_directories(
+      command,
       quiet: args.quiet?,
       word_diff: args.word_diff?
     )

--- a/lib/diff-scripts/service_diff.rb
+++ b/lib/diff-scripts/service_diff.rb
@@ -6,19 +6,16 @@ require "simulate_system"
 require "tap"
 
 # Expects:
-# 1. Temporary directory that exists
-# 2. Command type from VALID_COMMAND_TYPES
-# 3. Command arg
+# 1. Command type from VALID_COMMAND_TYPES
+# 2. Command arg
 #    - for command type `tap` it should be the name of a tap
 #    - for command type `formula` it should be the name of a formula
 #    - for command type `all` it is NOT necessary
-TMP_DIR, COMMAND_TYPE, COMMAND_ARG, *extra = ARGV
+COMMAND_TYPE, COMMAND_ARG, *extra = ARGV
 
 VALID_COMMAND_TYPES = %w[all tap formula].freeze
 
-if !Dir.exist?(TMP_DIR)
-  odie "Temporary directory `#{TMP_DIR}` does not exist!"
-elsif !VALID_COMMAND_TYPES.include?(COMMAND_TYPE)
+if !VALID_COMMAND_TYPES.include?(COMMAND_TYPE)
   odie "Unknown command type `#{COMMAND_TYPE}`!"
 elsif COMMAND_TYPE == "all" && COMMAND_ARG
   odie "Unexpected command arg `#{COMMAND_ARG}` for `all` command!"
@@ -42,7 +39,7 @@ if formula_files.empty?
   odie "No formulae with service blocks to compare according to the given criteria!"
 end
 
-MACOS_DIR = Pathname(TMP_DIR)/"macos"
+MACOS_DIR = Pathname("macos").expand_path
 MACOS_DIR.mkdir
 
 Homebrew::SimulateSystem.with(os: :macos) do
@@ -63,7 +60,7 @@ Homebrew::SimulateSystem.with(os: :macos) do
   end
 end
 
-LINUX_DIR = Pathname(TMP_DIR)/"linux"
+LINUX_DIR = Pathname("linux").expand_path
 LINUX_DIR.mkdir
 
 Homebrew::SimulateSystem.with(os: :linux) do

--- a/lib/hd-utils/branch_diff.rb
+++ b/lib/hd-utils/branch_diff.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "tempfile"
+require "tmpdir"
 
 module HDUtils
   module BranchDiff
@@ -60,6 +61,56 @@ module HDUtils
         end
   
         output_files.each(&:unlink)
+      ensure
+        # Return user to the correct branch in the event of a failure
+        system("git checkout #{current_branch}", out: File::NULL, err: File::NULL)
+      end  
+    end
+
+    def self.run_script(script_path, *script_args, quiet:, word_diff:)
+      odie "Script #{script_path} doesn't exist!" unless File.exist?(script_path)
+
+      quiet_options = quiet ? { out: File::NULL, err: File::NULL } : {}
+
+      Dir.chdir(HOMEBREW_REPOSITORY) do
+        master_branch = "master"
+        current_branch = `git branch --show-current`.strip
+
+        if master_branch == current_branch
+          odie "Current branch is the master branch. Switch to a feature branch and try again."
+        end
+
+        output_directories = [
+          master_branch,
+          current_branch,
+        ].map do |branch|
+          unless system("git checkout #{branch}", **quiet_options)
+            odie "error checking out #{branch} branch"
+          end
+
+          tmp_dir = Dir.mktmpdir(branch)
+          at_exit { FileUtils.remove_entry(tmp_dir) }
+
+          command = [HOMEBREW_BREW_FILE, "ruby", "--", script_path, tmp_dir, *script_args].join(" ")
+
+          unless system({"HOMEBREW_NO_AUTO_UPDATE" => "1"}, command)
+            odie "failure on #{branch} branch"
+          end
+
+          tmp_dir
+        end
+
+        master_branch_out_dir, current_branch_out_dir = output_directories
+
+        diff_command = %w[git diff --no-index]
+        diff_command << "--word-diff" if word_diff
+        diff_command << "--no-color" if ENV["HOMEBREW_NO_COLOR"]
+        diff_command << master_branch_out_dir
+        diff_command << current_branch_out_dir
+
+        unless system(*diff_command)
+          Homebrew.failed = true
+        end
       ensure
         # Return user to the correct branch in the event of a failure
         system("git checkout #{current_branch}", out: File::NULL, err: File::NULL)

--- a/lib/hd-utils/branch_diff.rb
+++ b/lib/hd-utils/branch_diff.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "tempfile"
+
+module HDUtils
+  module BranchDiff
+    def self.run_command(command, quiet:, word_diff:, with_stderr: false, ignore_errors: false)
+      if command.first == "brew"
+        odie "`brew` is not needed at the beginning of the subcommand"
+      elsif !system("brew command #{command.first}", out: File::NULL, err: File::NULL)
+        odie "Unknown command: `brew #{command.first}`"
+      end
+
+      quiet_options = quiet ? { out: File::NULL, err: File::NULL } : {}
+      spawn_options = with_stderr ? { err: [:child, :out] } : {}
+  
+      Dir.chdir(HOMEBREW_REPOSITORY) do
+        master_branch = "master"
+        current_branch = `git branch --show-current`.strip
+  
+        if master_branch == current_branch
+          odie "Current branch is the master branch. Switch to a feature branch and try again."
+        end
+        
+        output_files = [
+          master_branch,
+          current_branch,
+        ].map do |branch|
+          unless system("git checkout #{branch}", **quiet_options)
+            odie "error checking out #{branch} branch"
+          end
+          
+          outfile = Tempfile.new(branch)
+          IO.popen(
+            {"HOMEBREW_NO_AUTO_UPDATE" => "1"},
+            [HOMEBREW_BREW_FILE, *command],
+            **spawn_options
+          ) do |pipe|
+            outfile.write pipe.read
+          end
+          outfile.close
+  
+          if !ignore_errors && !$CHILD_STATUS.exitstatus.zero?
+            odie "failure on #{branch} branch"
+          end
+  
+          outfile
+        end
+  
+        master_branch_outfile, current_branch_outfile = output_files.map(&:path)
+  
+        diff_command = %w[git diff --no-index]
+        diff_command << "--word-diff" if word_diff
+        diff_command << "--no-color" if ENV["HOMEBREW_NO_COLOR"]
+        diff_command << master_branch_outfile
+        diff_command << current_branch_outfile
+  
+        unless system(*diff_command)
+          Homebrew.failed = true
+        end
+  
+        output_files.each(&:unlink)
+      ensure
+        # Return user to the correct branch in the event of a failure
+        system("git checkout #{current_branch}", out: File::NULL, err: File::NULL)
+      end  
+    end
+  end
+end

--- a/lib/hd_utils.rb
+++ b/lib/hd_utils.rb
@@ -8,5 +8,6 @@ $LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
 
 module HDUtils
   autoload :APIReadall, "hd-utils/api_readall"
+  autoload :BranchDiff, "hd-utils/branch_diff"
   autoload :StubAPI, "hd-utils/stub_api"
 end

--- a/scripts/service_diff.rb
+++ b/scripts/service_diff.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "formula"
+require "formulary"
+require "simulate_system"
+require "tap"
+
+# Expects:
+# 1. Temporary directory that exists
+# 2. Command type from VALID_COMMAND_TYPES
+# 3. Command arg
+#    - for command type `tap` it should be the name of a tap
+#    - for command type `formula` it should be the name of a formula
+#    - for command type `all` it is NOT necessary
+TMP_DIR, COMMAND_TYPE, COMMAND_ARG, *extra = ARGV
+
+VALID_COMMAND_TYPES = %w[all tap formula].freeze
+
+if !Dir.exist?(TMP_DIR)
+  odie "Temporary directory `#{TMP_DIR}` does not exist!"
+elsif !VALID_COMMAND_TYPES.include?(COMMAND_TYPE)
+  odie "Unknown command type `#{COMMAND_TYPE}`!"
+elsif COMMAND_TYPE == "all" && COMMAND_ARG
+  odie "Unexpected command arg `#{COMMAND_ARG}` for `all` command!"
+elsif extra.any?
+  odie "Unexpected additional arguments `#{extra}`!"
+end
+
+formula_files =
+  case COMMAND_TYPE
+  when "all"
+    Formula.all(eval_all: true)
+  when "tap"
+    Tap.fetch(COMMAND_ARG).formula_files.map(&Formulary.method(:factory))
+  when "formula"
+    [Formulary.factory(COMMAND_ARG)]
+  end
+  .select { |f| f.service? || f.plist }
+  .map(&:path)
+
+if formula_files.empty?
+  odie "No formulae with service blocks to compare according to the given criteria!"
+end
+
+MACOS_DIR = Pathname(TMP_DIR)/"macos"
+MACOS_DIR.mkdir
+
+Homebrew::SimulateSystem.with(os: :macos) do
+  formula_files.each do |formula_file|
+    formula = Formulary.factory(formula_file)
+
+    service_content =
+      if formula.service.command?
+        formula.service.to_plist
+      elsif formula.plist
+        formula.plist
+      end
+
+    next if service_content.nil?
+
+    outfile = MACOS_DIR/"#{formula.plist_name}.plist"
+    File.write(outfile, service_content)
+  end
+end
+
+LINUX_DIR = Pathname(TMP_DIR)/"linux"
+LINUX_DIR.mkdir
+
+Homebrew::SimulateSystem.with(os: :linux) do
+  formula_files.each do |formula_file|
+    formula = Formulary.factory(formula_file)
+
+    if formula.service? && formula.service.command?
+      outfile = LINUX_DIR/"#{formula.service_name}.service"
+      File.write(outfile, formula.service.to_systemd_unit)
+
+      if formula.service.timed?
+        outfile = LINUX_DIR/"#{formula.service_name}.timer"
+        File.write(outfile, formula.service.to_systemd_timer)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #2

This command essentially creates services files associated with all services
and then diffs them with each other recursively. The hope here is to make
it easier to confidently make changes to the service DSL.

TODO:
- [x] Add better documentation around `HDUtils::BranchDiff` methods
- [ ] ~Add readme to the `scripts/` directory~
- [x] Add command help page to readme