### PR TITLE
Add warning for git actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ testing when making changes to important commands.
 
 Example: brew branch-compare --quiet -- deps --installed
 
+Warning: This command uses git functions on the main brew repo. To be safe avoid
+running other brew commands simultaneously.
+
       --ignore-errors              Continue diff when a command returns a
                                    non-zero exit code.
       --with-stderr                Combine stdout and stderr in diff output.
@@ -58,7 +61,8 @@ Compare the service file generation on macOS and Linux before and after changes
 to brew. This helps with debugging and assurance testing when making changes to
 the brew services DSL.
 
-Note: By default it compares all formula files with services defined.
+Warning: This command uses git functions on the main brew repo. To be safe avoid
+running other brew commands simultaneously.
 
       --formula                    Run the diff on only one formula.
       --tap                        Run the diff on only one tap.

--- a/cmd/branch-compare.rb
+++ b/cmd/branch-compare.rb
@@ -13,6 +13,8 @@ module Homebrew
         and assurance testing when making changes to important commands.
 
         Example: `brew branch-compare --quiet -- deps --installed`
+
+        #{HDUtils::BranchDiff::WARNING_MESSAGE}
       EOS
 
       switch "--ignore-errors", description: "Continue diff when a command returns a non-zero exit code."

--- a/cmd/service-diff.rb
+++ b/cmd/service-diff.rb
@@ -12,7 +12,7 @@ module Homebrew
         and after changes to brew. This helps with debugging and assurance
         testing when making changes to the `brew services` DSL.
 
-        Note: By default it compares all formula files with services defined.
+        #{HDUtils::BranchDiff::WARNING_MESSAGE}
       EOS
 
       flag "--formula=", description: "Run the diff on only one formula."

--- a/lib/hd-utils/branch_diff.rb
+++ b/lib/hd-utils/branch_diff.rb
@@ -6,6 +6,11 @@ require "tmpdir"
 
 module HDUtils
   module BranchDiff
+    WARNING_MESSAGE = <<~EOS.chomp.freeze
+      Warning: This command uses git functions on the main brew repo.
+      To be safe avoid running other brew commands simultaneously.
+    EOS
+
     # Run a brew command on two branches and compare the output.
     def self.diff_output(command, quiet:, word_diff:, with_stderr:, ignore_errors:)
       if command.first == "brew"


### PR DESCRIPTION
There are now multiple commands which make use of git commands to create output diffs between brew branches. This is potentially harmful if the user is running a brew command with another branch or has changes already. We try to check for those things but it's not 100% safe. So we should warn users about that behavior.