### PR TITLE
Add more options to the branch-compare command

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Example: brew branch-compare --quiet -- deps --installed
                                    non-zero exit code.
       --with-stderr                Combine stdout and stderr in diff output.
       --word-diff                  Show word diff instead of default line diff.
+      --time                       Benchmark the command on both branches.
+      --local                      Only load formula/cask from local taps not
+                                   the API.
   -d, --debug                      Display any debugging information.
   -q, --quiet                      Make some output more quiet.
   -v, --verbose                    Make some output more verbose.

--- a/cmd/branch-compare.rb
+++ b/cmd/branch-compare.rb
@@ -18,6 +18,8 @@ module Homebrew
       switch "--ignore-errors", description: "Continue diff when a command returns a non-zero exit code."
       switch "--with-stderr", description: "Combine stdout and stderr in diff output."
       switch "--word-diff", description: "Show word diff instead of default line diff."
+      switch "--time", description: "Benchmark the command on both branches."
+      switch "--local", description: "Only load formula/cask from local taps not the API."
 
       named_args :command, min: 1
     end
@@ -33,6 +35,8 @@ module Homebrew
       word_diff:     args.word_diff?,
       with_stderr:   args.with_stderr?,
       ignore_errors: args.ignore_errors?,
+      no_api:        args.local?,
+      benchmark:     args.time?,
     )
   end
 end

--- a/lib/diff-scripts/service_diff.rb
+++ b/lib/diff-scripts/service_diff.rb
@@ -23,56 +23,58 @@ elsif extra.any?
   odie "Unexpected additional arguments `#{extra}`!"
 end
 
-formula_files =
-  case COMMAND_TYPE
-  when "all"
-    Formula.all(eval_all: true)
-  when "tap"
-    Tap.fetch(COMMAND_ARG).formula_files.map(&Formulary.method(:factory))
-  when "formula"
-    [Formulary.factory(COMMAND_ARG)]
-  end
-  .select { |f| f.service? || f.plist }
-  .map(&:path)
-
-odie "No formulae with service blocks to compare according to the given criteria!" if formula_files.empty?
-
 MACOS_DIR = Pathname("macos").expand_path.freeze
 MACOS_DIR.mkdir
-
-Homebrew::SimulateSystem.with(os: :macos) do
-  formula_files.each do |formula_file|
-    formula = Formulary.factory(formula_file)
-
-    service_content =
-      if formula.service.command?
-        formula.service.to_plist
-      elsif formula.plist
-        formula.plist
-      end
-
-    next if service_content.nil?
-
-    outfile = MACOS_DIR/"#{formula.plist_name}.plist"
-    File.write(outfile, service_content)
-  end
-end
 
 LINUX_DIR = Pathname("linux").expand_path.freeze
 LINUX_DIR.mkdir
 
-Homebrew::SimulateSystem.with(os: :linux) do
-  formula_files.each do |formula_file|
-    formula = Formulary.factory(formula_file)
+Homebrew.with_no_api_env do
+  formula_files =
+    case COMMAND_TYPE
+    when "all"
+      Formula.all(eval_all: true)
+    when "tap"
+      Tap.fetch(COMMAND_ARG).formula_files.map(&Formulary.method(:factory))
+    when "formula"
+      [Formulary.factory(COMMAND_ARG)]
+    end
+    .select { |f| f.service? || f.plist }
+    .map(&:path)
 
-    next unless formula.service.command?
+  odie "No formulae with service blocks to compare according to the given criteria!" if formula_files.empty?
 
-    outfile = LINUX_DIR/"#{formula.service_name}.service"
-    File.write(outfile, formula.service.to_systemd_unit)
+  Homebrew::SimulateSystem.with(os: :macos) do
+    formula_files.each do |formula_file|
+      formula = Formulary.factory(formula_file)
 
-    if formula.service.timed?
-      outfile = LINUX_DIR/"#{formula.service_name}.timer"
-      File.write(outfile, formula.service.to_systemd_timer)
+      service_content =
+        if formula.service.command?
+          formula.service.to_plist
+        elsif formula.plist
+          formula.plist
+        end
+
+      next if service_content.nil?
+
+      outfile = MACOS_DIR/"#{formula.plist_name}.plist"
+      File.write(outfile, service_content)
+    end
+  end
+
+  Homebrew::SimulateSystem.with(os: :linux) do
+    formula_files.each do |formula_file|
+      formula = Formulary.factory(formula_file)
+
+      next unless formula.service.command?
+
+      outfile = LINUX_DIR/"#{formula.service_name}.service"
+      File.write(outfile, formula.service.to_systemd_unit)
+
+      if formula.service.timed?
+        outfile = LINUX_DIR/"#{formula.service_name}.timer"
+        File.write(outfile, formula.service.to_systemd_timer)
+      end
     end
   end
 end

--- a/lib/hd-utils/branch_diff.rb
+++ b/lib/hd-utils/branch_diff.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "benchmark"
 require "shellwords"
 require "tempfile"
 require "tmpdir"
@@ -7,7 +8,7 @@ require "tmpdir"
 module HDUtils
   module BranchDiff
     # Run a brew command on two branches and compare the output.
-    def self.diff_output(command, quiet:, word_diff:, with_stderr:, ignore_errors:)
+    def self.diff_output(command, quiet:, word_diff:, with_stderr:, ignore_errors:, no_api:, benchmark:)
       if command.first == "brew"
         odie "`brew` is not needed at the beginning of the subcommand"
       elsif !system("brew command #{command.first}", out: File::NULL, err: File::NULL)
@@ -16,6 +17,11 @@ module HDUtils
 
       quiet_options = quiet ? { out: File::NULL, err: File::NULL } : {}
       spawn_options = with_stderr ? { err: [:child, :out] } : {}
+      env_variables = {}.tap do |hash|
+        hash["HOMEBREW_NO_AUTO_UPDATE"] = "1"
+        hash["HOMEBREW_NO_INSTALL_FROM_API"] = "1" if no_api
+      end
+      benchmark_results = []
 
       Dir.chdir(HOMEBREW_REPOSITORY) do
         master_branch = "master"
@@ -34,14 +40,14 @@ module HDUtils
           odie "error checking out #{branch} branch" unless system("git checkout #{branch}", **quiet_options)
 
           outfile = Tempfile.new(branch)
-          IO.popen(
-            { "HOMEBREW_NO_AUTO_UPDATE" => "1" },
-            [HOMEBREW_BREW_FILE, *command],
-            **spawn_options,
-          ) do |pipe|
-            outfile.write pipe.read
+          time = Benchmark.measure do
+            IO.popen(env_variables, [HOMEBREW_BREW_FILE, *command], **spawn_options) do |pipe|
+              outfile.write pipe.read
+            end
           end
           outfile.close
+
+          benchmark_results << "#{branch} : #{time.real.round(2)} seconds"
 
           odie "failure on #{branch} branch" if !ignore_errors && !$CHILD_STATUS.exitstatus.zero?
 
@@ -59,6 +65,13 @@ module HDUtils
         Homebrew.failed = true unless system(*diff_command)
 
         output_files.each(&:unlink)
+
+        if benchmark
+          puts
+          puts "Benchmark Results"
+          puts "--------- -------"
+          benchmark_results.each(&method(:puts))
+        end
       ensure
         # Return user to the correct branch in the event of a failure
         system("git checkout #{current_branch}", out: File::NULL, err: File::NULL)


### PR DESCRIPTION
- `--local` option only loads files from local taps
- `--time` option shows benchmarking results for each branch

I also updated some code so that the service-diff command always runs with HOMEBREW_NO_INSTALL_FROM_API.

Closes #12