### PR TITLE
Add generate-api-diff command

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,28 @@ running other brew commands simultaneously.
   -h, --help                       Show this message.
 ```
 
+### brew generate-api-diff
+
+```
+Usage: brew generate-api-diff [options]
+
+Compare the API generation before and and after changes to brew. This helps with
+debugging and assurance testing when making changes to the JSON API.
+
+Note: One of the --cask or --formula options is required.
+
+Warning: This command uses git functions on the main brew repo. To be safe avoid
+running other brew commands simultaneously.
+
+      --cask                       Run the diff on only core casks.
+      --formula                    Run the diff on only core formulae.
+      --word-diff                  Show word diff instead of default line diff.
+  -d, --debug                      Display any debugging information.
+  -q, --quiet                      Make some output more quiet.
+  -v, --verbose                    Make some output more verbose.
+  -h, --help                       Show this message.
+```
+
 ### brew service-diff
 
 ```
@@ -86,8 +108,7 @@ running other brew commands simultaneously.
   - `rake readme:generate`
 - Integration Tests
   - `rake test:all`
-    - Runs all of the following tests
-  - `rake test:api-readall-test`
-    - Very slow!
+  - `rake test:api-readall-test` (SLOW)
   - `rake test:branch-compare`
+  - `rake test:generate-api-diff` (SLOW)
   - `rake test:service-diff`

--- a/Rakefile
+++ b/Rakefile
@@ -37,7 +37,7 @@ def with_test_branch
     ensure
       log "Cleanup"
       sh "git", "checkout", current_branch
-      sh "git", "branch", "-d", test_branch
+      sh "git", "branch", "-D", test_branch
     end
   end
 end
@@ -93,6 +93,13 @@ namespace "test" do
     end
   end
 
+  task :"generate-api-diff" do
+    with_test_branch do
+      cmd "brew", "generate-api-diff", "--cask"
+      cmd "brew", "generate-api-diff", "--formula"
+    end
+  end
+
   task :"service-diff" do
     with_test_branch do
       cmd "brew", "service-diff", "--formula=redis"
@@ -103,6 +110,7 @@ namespace "test" do
     %w[
       test:api-readall-test
       test:branch-compare
+      test:generate-api-diff
       test:service-diff
     ].each_with_index do |task, index|
       puts "--------------------" if index.positive?

--- a/cmd/generate-api-diff.rb
+++ b/cmd/generate-api-diff.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "cli/parser"
+require_relative "../lib/hd_utils"
+
+module Homebrew
+  def self.generate_api_diff_args
+    Homebrew::CLI::Parser.new do
+      usage_banner "`generate-api-diff` [<options>]"
+      description <<~EOS
+        Compare the API generation before and and after changes
+        to brew. This helps with debugging and assurance
+        testing when making changes to the JSON API.
+
+        Note: One of the `--cask` or `--formula` options is required.
+
+        #{HDUtils::BranchDiff::WARNING_MESSAGE}
+      EOS
+
+      switch "--cask", description: "Run the diff on only core casks."
+      switch "--formula", description: "Run the diff on only core formulae."
+      switch "--word-diff", description: "Show word diff instead of default line diff."
+
+      conflicts "--cask", "--formula"
+    end
+  end
+
+  def self.generate_api_diff
+    args = generate_api_diff_args.parse
+
+    command =
+      if args.formula?
+        [HOMEBREW_BREW_FILE, "generate-formula-api"]
+      elsif args.cask?
+        [HOMEBREW_BREW_FILE, "generate-cask-api"]
+      else
+        require "help"
+        Homebrew::Help.help "generate-api-diff"
+      end
+
+    HDUtils::BranchDiff.diff_directories(
+      command,
+      quiet:     args.quiet?,
+      word_diff: args.word_diff?,
+      no_api:    true,
+    )
+  end
+end

--- a/cmd/service-diff.rb
+++ b/cmd/service-diff.rb
@@ -44,6 +44,7 @@ module Homebrew
       command,
       quiet:     args.quiet?,
       word_diff: args.word_diff?,
+      no_api:    true,
     )
   end
 end

--- a/lib/diff-scripts/service_diff.rb
+++ b/lib/diff-scripts/service_diff.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# NOTE: This file should be run with HOMEBREW_NO_INSTALL_FROM_API set.
+
 require "formula"
 require "formulary"
 require "simulate_system"
@@ -23,58 +25,56 @@ elsif extra.any?
   odie "Unexpected additional arguments `#{extra}`!"
 end
 
+formula_files =
+  case COMMAND_TYPE
+  when "all"
+    Formula.all(eval_all: true)
+  when "tap"
+    Tap.fetch(COMMAND_ARG).formula_files.map(&Formulary.method(:factory))
+  when "formula"
+    [Formulary.factory(COMMAND_ARG)]
+  end
+  .select { |f| f.service? || f.plist }
+  .map(&:path)
+
+odie "No formulae with service blocks to compare according to the given criteria!" if formula_files.empty?
+
 MACOS_DIR = Pathname("macos").expand_path.freeze
 MACOS_DIR.mkdir
+
+Homebrew::SimulateSystem.with(os: :macos) do
+  formula_files.each do |formula_file|
+    formula = Formulary.factory(formula_file)
+
+    service_content =
+      if formula.service.command?
+        formula.service.to_plist
+      elsif formula.plist
+        formula.plist
+      end
+
+    next if service_content.nil?
+
+    outfile = MACOS_DIR/"#{formula.plist_name}.plist"
+    File.write(outfile, service_content)
+  end
+end
 
 LINUX_DIR = Pathname("linux").expand_path.freeze
 LINUX_DIR.mkdir
 
-Homebrew.with_no_api_env do
-  formula_files =
-    case COMMAND_TYPE
-    when "all"
-      Formula.all(eval_all: true)
-    when "tap"
-      Tap.fetch(COMMAND_ARG).formula_files.map(&Formulary.method(:factory))
-    when "formula"
-      [Formulary.factory(COMMAND_ARG)]
-    end
-    .select { |f| f.service? || f.plist }
-    .map(&:path)
+Homebrew::SimulateSystem.with(os: :linux) do
+  formula_files.each do |formula_file|
+    formula = Formulary.factory(formula_file)
 
-  odie "No formulae with service blocks to compare according to the given criteria!" if formula_files.empty?
+    next unless formula.service.command?
 
-  Homebrew::SimulateSystem.with(os: :macos) do
-    formula_files.each do |formula_file|
-      formula = Formulary.factory(formula_file)
+    outfile = LINUX_DIR/"#{formula.service_name}.service"
+    File.write(outfile, formula.service.to_systemd_unit)
 
-      service_content =
-        if formula.service.command?
-          formula.service.to_plist
-        elsif formula.plist
-          formula.plist
-        end
-
-      next if service_content.nil?
-
-      outfile = MACOS_DIR/"#{formula.plist_name}.plist"
-      File.write(outfile, service_content)
-    end
-  end
-
-  Homebrew::SimulateSystem.with(os: :linux) do
-    formula_files.each do |formula_file|
-      formula = Formulary.factory(formula_file)
-
-      next unless formula.service.command?
-
-      outfile = LINUX_DIR/"#{formula.service_name}.service"
-      File.write(outfile, formula.service.to_systemd_unit)
-
-      if formula.service.timed?
-        outfile = LINUX_DIR/"#{formula.service_name}.timer"
-        File.write(outfile, formula.service.to_systemd_timer)
-      end
+    if formula.service.timed?
+      outfile = LINUX_DIR/"#{formula.service_name}.timer"
+      File.write(outfile, formula.service.to_systemd_timer)
     end
   end
 end

--- a/scripts/generate_readme.rb
+++ b/scripts/generate_readme.rb
@@ -49,10 +49,9 @@ File.open("#{__dir__}/../README.md.new", "w") do |out_file|
       - `rake readme:generate`
     - Integration Tests
       - `rake test:all`
-        - Runs all of the following tests
-      - `rake test:api-readall-test`
-        - Very slow!
+      - `rake test:api-readall-test` (SLOW)
       - `rake test:branch-compare`
+      - `rake test:generate-api-diff` (SLOW)
       - `rake test:service-diff`
   EOS
 end


### PR DESCRIPTION
This command compares JSON API generation on both branches.

Other changes:
- Removed with no API env from service_diff.rb script
- Handle HOMEBREW_NO_INSTALL_FROM_API in BranchDiff module
- Add better debug info to BranchDiff methods
- Update readme
- Update tests in Rakefile

Closes #15