### PR TITLE
Add integration tests to CI

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,0 +1,31 @@
+name: CI
+on:
+  schedule:
+  - cron: '0 10 * * Sun'
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    runs-on: macos-latest
+    steps:
+    - name: Set up Homebrew
+      id: set-up-homebrew
+      uses: Homebrew/actions/setup-homebrew@master
+      with:
+        core: true
+        cask: true
+        test-bot: false
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '2.7'
+
+    - run: rake test:api-readall-test
+
+    - run: rake test:branch-compare
+
+    - run: rake test:generate-api-diff
+
+    - run: rake test:service-diff

--- a/.github/workflows/merge_checks.yml
+++ b/.github/workflows/merge_checks.yml
@@ -13,6 +13,10 @@ jobs:
     - name: Set up Homebrew
       id: set-up-homebrew
       uses: Homebrew/actions/setup-homebrew@master
+      with:
+        core: false
+        cask: false
+        test-bot: false
 
     - name: Cache Homebrew Bundler RubyGems
       id: cache
@@ -31,6 +35,11 @@ jobs:
       with:
         ruby-version: '2.7'
 
-    - run: rake lint:check
+    - name: Lint Ruby code
+      run: rake lint:check
 
-    - run: rake readme:outdated 
+    - name: Check if readme is outdated
+      run: rake readme:outdated
+
+    - name: Check for missing integration tests
+      run: rake missing-tests

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ running other brew commands simultaneously.
 
 ## Development
 
+Linting and readme checks are run on each pull request while integration tests are only run weekly.
+
 - Linting
   - `rake lint:check`
   - `rake lint:fix`
@@ -107,6 +109,7 @@ running other brew commands simultaneously.
   - `rake readme:outdated`
   - `rake readme:generate`
 - Integration Tests
+  - `rake missing-tests`
   - `rake test:all`
   - `rake test:api-readall-test` (SLOW)
   - `rake test:branch-compare`

--- a/scripts/generate_readme.rb
+++ b/scripts/generate_readme.rb
@@ -41,6 +41,8 @@ File.open("#{__dir__}/../README.md.new", "w") do |out_file|
 
     ## Development
 
+    Linting and readme checks are run on each pull request while integration tests are only run weekly.
+
     - Linting
       - `rake lint:check`
       - `rake lint:fix`
@@ -48,6 +50,7 @@ File.open("#{__dir__}/../README.md.new", "w") do |out_file|
       - `rake readme:outdated`
       - `rake readme:generate`
     - Integration Tests
+      - `rake missing-tests`
       - `rake test:all`
       - `rake test:api-readall-test` (SLOW)
       - `rake test:branch-compare`


### PR DESCRIPTION
These don't necessarily need to run before every merge but should run occasionally so that we can better react to upstream brew changes. This codebase uses a lot of undocumented internal brew APIs so it shouldn't be surprising when one of them breaks.

I'm planning on running these integration tests weekly.

Closes #22