### PR TITLE
Use stderr in rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ def log(text)
 end
 
 def cmd(*command)
-  print "$ "
+  $stderr.print "$ "
   sh(*command)
 end
 


### PR DESCRIPTION
In Github Actions, there was some text which didn't sync up correctly and when I looked at the Rake code I found that it uses stderr by default. The hope is that by using stderr for all print statements in the Rakefile that the text will be synced up.