### PR TITLE
Let brew install gems automatically in CI

### DIFF
--- a/.github/workflows/merge_checks.yml
+++ b/.github/workflows/merge_checks.yml
@@ -18,18 +18,6 @@ jobs:
         cask: false
         test-bot: false
 
-    - name: Cache Homebrew Bundler RubyGems
-      id: cache
-      uses: actions/cache@v3
-      with:
-        path: ${{ steps.set-up-homebrew.outputs.gems-path }}
-        key: ubuntu-latest-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
-        restore-keys: ubuntu-latest-rubygems-
-
-    - name: Install Homebrew Bundler RubyGems
-      if: steps.cache.outputs.cache-hit != 'true'
-      run: brew install-bundler-gems
-
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
Bo made some really nice changes to how gems are installed in brew so I think it will do a better job of choosing to install only the gems necessary for the command that's getting called.

This means we can remove manual gem installation and trust that brew will just do the right thing.