### PR TITLE
POC `brew grep` command

### DIFF
--- a/cmd/branch-compare.rb
+++ b/cmd/branch-compare.rb
@@ -23,7 +23,7 @@ module Homebrew
       switch "--time", description: "Benchmark the command on both branches."
       switch "--local", description: "Only load formula/cask from local taps not the API."
 
-      named_args :command, min: 1
+      named_args :command, number: 1
     end
   end
 

--- a/cmd/grep.rb
+++ b/cmd/grep.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+module Homebrew
+  def self.grep_args
+    Homebrew::CLI::Parser.new do
+      usage_banner "`grep` <query>"
+      description <<~EOS
+        Search for matching name and description data in casks and formula
+        using `git grep`. This only works for local taps and not with the
+        core JSON APIs.
+
+        This is mostly just a proof-of-concept alternative to `brew desc`
+        which doesn't require
+      EOS
+
+      named_args number: 1
+    end
+  end
+
+  # Ex. `homebrew/homebrew-cask/Casks/a/all-in-one-messenger.rb:  name "All-in-One Messenger"`
+  NAME_OR_DESC_REGEX = %r{
+    ^
+    (?<user>[\w-]+)/            # homebrew/
+    (:?homebrew-)?              # homebrew-
+    (?<repo>[\w-]+)/            # cask-fonts/
+    (?<cask>(:?Casks/)?)        # Casks/
+    (:?[^/]+/)*                 # a/
+    (?<package>\S+)\.rb         # all-in-one-messenger.rb
+    :\s\s                       # `:  `
+    (?<command>name|desc)       # name
+    \s+                         # ` `
+    "(?<string>(:?[^"]|\\")+)"  # "All-in-One Messenger"
+    \s*
+    $
+  }x.freeze
+
+  def self.query_to_regex(query)
+    query.downcase
+         .gsub(/[^a-z0-9]/, "")
+         .chars
+         .join("[^a-z0-9]*")
+         .then { |query| /#{query}/i }
+         .freeze
+  end
+
+  def self.grep
+    args = grep_args.parse
+    query = args.named.first
+    query = query_to_regex(query)
+
+    git_grep = [
+      "git", "-C", (HOMEBREW_LIBRARY / "Taps").to_s,
+      "grep", "--no-index",
+      "-E", "^  (desc|name)[ ]+\"",
+      "--", "*.rb"
+    ].freeze
+
+    cask_names = Hash.new { |hash, key| hash[key] = [] }
+    cask_descriptions = {}
+    formula_descriptions = {}
+
+    Utils.safe_popen_read(*git_grep).lines.each do |line|
+      match = line.match(NAME_OR_DESC_REGEX)
+      next (puts line) if match.nil?
+
+      case match[:command]
+      when "desc"
+        if match[:cask].empty?
+          formula_descriptions[match[:package]] = match[:string]
+        else
+          cask_descriptions[match[:package]] = match[:string]
+        end
+      when "name"
+        cask_names[match[:package]] << match[:string]
+      end
+    end
+
+    cask_names.transform_values! { |names| names.join(", ") }
+
+    formulae = formula_descriptions.select do |name, description|
+      query.match?(name) || query.match?(description)
+    end
+
+    ohai "Formulae"
+    formulae.sort_by(&:first).each do |name, desc|
+      puts "#{Tty.bold}#{name}:#{Tty.reset} #{desc}"
+    end
+    puts
+
+    casks = (cask_descriptions.keys | cask_names.keys).select do |name|
+      query.match?(name) || cask_names[name]&.match?(query) || cask_descriptions[name]&.match?(query)
+    end
+
+    ohai "Casks"
+    casks.each do |name|
+      names = cask_names.fetch(name)
+      desc = cask_descriptions.fetch(name, "[no description]")
+      puts "#{Tty.bold}#{name}:#{Tty.reset} (#{names}) #{desc}"
+    end
+
+    Homebrew.failed = true if formulae.empty? && casks.empty?
+  end
+end


### PR DESCRIPTION
Tangentially related to https://github.com/Homebrew/brew/issues/16237

This is an exploration of statically parsing the cask/formula files using grep + regexes to see if it is fast enough to allow us to parse that information on the fly each time and see if it's accurate enough to make the old command obsolete. The old technique required caching descriptions which is extra complexity and can be a security risk since it means that all package files are evaluated.

As is this is super hacky but it does show that this is a viable solution to the problem.

```console
$ brew grep blue
==> Formulae
blazegraph: Graph database supporting RDF data model, Sesame, and Blueprint APIs
bluepill: Testing tool for iOS that runs UI tests using multiple simulators
bluetoothconnector: Connect and disconnect Bluetooth devices
blueutil: Get/set bluetooth power and discoverable state
drafter: Native C/C++ API Blueprint Parser
hidapi: Library for communicating with USB and Bluetooth HID devices
libbtbb: Bluetooth baseband decoding library

==> Casks
font-bigblue-terminal-nerd-font: (BigBlueTerm Nerd Font families (BigBlue Terminal)) Developer targeted fonts with a high number of glyphs
airunlock: (AirUnlock) Tool to lock or unlock the macbook using an Android phone via Bluetooth
bleunlock: (BLEUnlock) Lock/unlock Apple computers using the proximity of a bluetooth low energy device
bluebubbles: (BlueBubbles) Server for forwarding iMessages
bluefish: (Bluefish) Open source code editor
bluegriffon: (BlueGriffon) Web and EPUB editor
blueharvest: (BlueHarvest) Remove metadata files from external drives
bluej: (BlueJ) Java Development Environment designed for beginners
bluejeans: (BlueJeans) Video conferencing for the digital workplace
bluesense: (BlueSense) Detect the presence of your Bluetooth device
bluesnooze: (Bluesnooze) Prevents your sleeping computer from connecting to Bluetooth accessories
bluestacks: (BlueStacks) Mobile gaming platform
bluetility: (Bluetility) Bluetooth Low Energy browser
bluewallet: (BlueWallet) Bitcoin wallet and Lightning wallet
bubo: (Bubo, Spotify Bluetooth Headset Listener) Fixes broken bluetooth headset control
flic: (Flic) Driver for the Flic bluetooth button
grs-bluewallet: (GRS BlueWallet) Groestlcoin wallet and Lightning wallet
iris: (Iris) Blue light filter and eye protection software
usb-overdrive: (USB Overdrive) USB and Bluetooth device driver
```

This is slower than the current `brew desc` command but not by much and this new command doesn't used cached data at all. The main worry here would be performance though.

```console
$ hyperfine 'brew desc --search --eval-all server' 'brew grep server'
Benchmark 1: brew desc --search --eval-all server
  Time (mean ± σ):      3.095 s ±  0.099 s    [User: 1.893 s, System: 1.013 s]
  Range (min … max):    3.018 s …  3.317 s    10 runs
 
Benchmark 2: brew grep server
  Time (mean ± σ):      3.564 s ±  0.023 s    [User: 2.111 s, System: 2.114 s]
  Range (min … max):    3.540 s …  3.602 s    10 runs
 
Summary
  brew desc --search --eval-all server ran
    1.15 ± 0.04 times faster than brew grep server
```