### PR TITLE
Fix api-readall-test and fail integration tests

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -29,16 +29,11 @@ jobs:
         bundler-cache: true
 
     - run: rake lint:check
-      continue-on-error: true
 
     - run: rake test:api-readall-test
-      continue-on-error: true
 
     - run: rake test:branch-compare
-      continue-on-error: true
 
     - run: rake test:generate-api-diff
-      continue-on-error: true
 
     - run: rake test:service-diff
-      continue-on-error: true

--- a/Rakefile
+++ b/Rakefile
@@ -131,9 +131,9 @@ RAKE_TEST_REGEX = /^\s+- run:\s+rake\s+test:([a-zA-Z_-]+)\s*$/
 task :"missing-tests" do
   abort "Missing integration test file: #{INTEGRATION_TESTS_FILE}" unless File.exist?(INTEGRATION_TESTS_FILE)
 
-  integration_tests = File.foreach(INTEGRATION_TESTS_FILE).map do |line|
+  integration_tests = File.foreach(INTEGRATION_TESTS_FILE).filter_map do |line|
     line[RAKE_TEST_REGEX, 1]
-  end.compact
+  end
 
   tap_commands = Dir.children("cmd").map do |file|
     file.chomp(".rb")

--- a/lib/hd-utils/stub-api/formula.rb
+++ b/lib/hd-utils/stub-api/formula.rb
@@ -38,7 +38,7 @@ module HDUtils
       end
 
       def self.load_from_api(name)
-        Formulary::FormulaAPILoader
+        Formulary::FromAPILoader
           .new(name)
           .get_formula(:stable)
       end


### PR DESCRIPTION
The formula api loader class got renamed recently and this change just reflects that.

I also actually want the integration tests to notify me when something goes wrong so they should fail loudly.