### PR TITLE
Update formula api loader references among other things

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,7 +1,10 @@
 name: Integration Tests
 on:
+  push:
+    branches: main
+  pull_request:
   schedule:
-  - cron: '0 10 * * Sun'
+  - cron: '0 10 * * Sat'
 permissions:
   contents: read
 

--- a/cmd/api-readall-test.rb
+++ b/cmd/api-readall-test.rb
@@ -26,6 +26,8 @@ module Homebrew
   def self.api_readall_test
     args = api_readall_test_args.parse
 
+    ENV.delete("HOMEBREW_INTERNAL_JSON_V3")
+
     Homebrew.with_no_api_env do
       unless args.cask?
         HDUtils::APIReadall::FormulaTest.run(

--- a/cmd/branch-compare.rb
+++ b/cmd/branch-compare.rb
@@ -31,6 +31,8 @@ module Homebrew
     args = branch_compare_args.parse
     command = args.named
 
+    ENV.delete("HOMEBREW_INTERNAL_JSON_V3")
+
     HDUtils::BranchDiff.diff_output(
       command,
       quiet:         args.quiet?,

--- a/cmd/generate-api-diff.rb
+++ b/cmd/generate-api-diff.rb
@@ -31,6 +31,8 @@ module Homebrew
   def self.generate_api_diff
     args = generate_api_diff_args.parse
 
+    ENV.delete("HOMEBREW_INTERNAL_JSON_V3")
+
     command =
       if args.formula?
         [HOMEBREW_BREW_FILE, "generate-formula-api"]

--- a/cmd/service-diff.rb
+++ b/cmd/service-diff.rb
@@ -28,6 +28,8 @@ module Homebrew
   def self.service_diff
     args = service_diff_args.parse
 
+    ENV.delete("HOMEBREW_INTERNAL_JSON_V3")
+
     script_path = File.expand_path("../lib/diff-scripts/service_diff.rb", __dir__)
     odie "Script #{script_path} doesn't exist!" unless File.exist?(script_path)
 

--- a/lib/diff-scripts/service_diff.rb
+++ b/lib/diff-scripts/service_diff.rb
@@ -128,7 +128,7 @@ MACOS_API_DIR.mkdir
 
 Homebrew::SimulateSystem.with(os: :macos) do
   CORE_FORMULAE_NAMES.each do |formula_name|
-    formula = Formulary::FormulaAPILoader.new(formula_name).get_formula(:stable)
+    formula = Formulary::FromAPILoader.new(formula_name).get_formula(:stable)
 
     service_content =
       if formula.service.command?
@@ -151,7 +151,7 @@ LINUX_API_DIR.mkdir
 
 Homebrew::SimulateSystem.with(os: :linux) do
   CORE_FORMULAE_NAMES.each do |formula_name|
-    formula = Formulary::FormulaAPILoader.new(formula_name).get_formula(:stable)
+    formula = Formulary::FromAPILoader.new(formula_name).get_formula(:stable)
 
     next unless formula.service.command?
 


### PR DESCRIPTION
- s/FormulaAPILoader/FromAPILoader/
  - This matches a recent change in the main brew repo
- delete `HOMEBREW_INTERNAL_JSON_V3` before each command
  - This should get updated at some point to work with the new JSON format
- run integration tests on each PR branch and when merging into main