### PR TITLE
Update commands to new DSL

### DIFF
--- a/cmd/api-readall-test.rb
+++ b/cmd/api-readall-test.rb
@@ -4,47 +4,47 @@ require "cli/parser"
 require_relative "../lib/hd_utils"
 
 module Homebrew
-  def self.api_readall_test_args
-    Homebrew::CLI::Parser.new do
-      usage_banner "`api-readall-test` [<options>]"
-      description <<~EOS
-        Test API generation and loading of core formulae and casks.
+  module Cmd
+    class ApiReadallTest < AbstractCommand
+      cmd_args do
+        usage_banner "`api-readall-test` [<options>]"
+        description <<~EOS
+          Test API generation and loading of core formulae and casks.
 
-        Note: This requires the core tap(s) to be installed locally,
-        `HOMEBREW_NO_INSTALL_FROM_API` gets set automatically before running and
-        this command is slow because it generates and then loads everything.
-      EOS
+          Note: This requires the core tap(s) to be installed locally,
+          `HOMEBREW_NO_INSTALL_FROM_API` gets set automatically before running and
+          this command is slow because it generates and then loads everything.
+        EOS
 
-      switch "--fail-fast", description: "Exit after the first failure."
-      switch "--formula", "--formulae", description: "Only test core formulae."
-      switch "--cask", "--casks", description: "Only test core casks."
+        switch "--fail-fast", description: "Exit after the first failure."
+        switch "--formula", "--formulae", description: "Only test core formulae."
+        switch "--cask", "--casks", description: "Only test core casks."
 
-      conflicts "--formula", "--cask"
-    end
-  end
-
-  def self.api_readall_test
-    args = api_readall_test_args.parse
-
-    ENV.delete("HOMEBREW_INTERNAL_JSON_V3")
-
-    Homebrew.with_no_api_env do
-      unless args.cask?
-        HDUtils::APIReadall::FormulaTest.run(
-          quiet:     args.quiet?,
-          verbose:   args.verbose?,
-          fail_fast: args.fail_fast?,
-        )
+        conflicts "--formula", "--cask"
       end
 
-      puts if !args.formula? && !args.cask?
+      def run
+        ENV.delete("HOMEBREW_INTERNAL_JSON_V3")
 
-      unless args.formula?
-        HDUtils::APIReadall::CaskTest.run(
-          quiet:     args.quiet?,
-          verbose:   args.verbose?,
-          fail_fast: args.fail_fast?,
-        )
+        Homebrew.with_no_api_env do
+          unless args.cask?
+            HDUtils::APIReadall::FormulaTest.run(
+              quiet:     args.quiet?,
+              verbose:   args.verbose?,
+              fail_fast: args.fail_fast?,
+            )
+          end
+
+          puts if !args.formula? && !args.cask?
+
+          unless args.formula?
+            HDUtils::APIReadall::CaskTest.run(
+              quiet:     args.quiet?,
+              verbose:   args.verbose?,
+              fail_fast: args.fail_fast?,
+            )
+          end
+        end
       end
     end
   end

--- a/cmd/branch-compare.rb
+++ b/cmd/branch-compare.rb
@@ -4,43 +4,44 @@ require "cli/parser"
 require_relative "../lib/hd_utils"
 
 module Homebrew
-  def self.branch_compare_args
-    Homebrew::CLI::Parser.new do
-      usage_banner "`branch-compare` [<options>] -- command"
-      description <<~EOS
-        Runs a brew command on both the current branch and the main branch
-        and then diffs the output of both commands. This helps with debugging
-        and assurance testing when making changes to important commands.
+  module Cmd
+    class BranchCompare < AbstractCommand
+      cmd_args do
+        usage_banner "`branch-compare` [<options>] -- command"
+        description <<~EOS
+          Runs a brew command on both the current branch and the main branch
+          and then diffs the output of both commands. This helps with debugging
+          and assurance testing when making changes to important commands.
 
-        Example: `brew branch-compare --quiet -- deps --installed`
+          Example: `brew branch-compare --quiet -- deps --installed`
 
-        #{HDUtils::BranchDiff::WARNING_MESSAGE}
-      EOS
+          #{HDUtils::BranchDiff::WARNING_MESSAGE}
+        EOS
 
-      switch "--ignore-errors", description: "Continue diff when a command returns a non-zero exit code."
-      switch "--with-stderr", description: "Combine stdout and stderr in diff output."
-      switch "--word-diff", description: "Show word diff instead of default line diff."
-      switch "--time", description: "Benchmark the command on both branches."
-      switch "--local", description: "Only load formula/cask from local taps not the API."
+        switch "--ignore-errors", description: "Continue diff when a command returns a non-zero exit code."
+        switch "--with-stderr", description: "Combine stdout and stderr in diff output."
+        switch "--word-diff", description: "Show word diff instead of default line diff."
+        switch "--time", description: "Benchmark the command on both branches."
+        switch "--local", description: "Only load formula/cask from local taps not the API."
 
-      named_args :command, min: 1
+        named_args :command, min: 1
+      end
+
+      def run
+        command = args.named
+
+        ENV.delete("HOMEBREW_INTERNAL_JSON_V3")
+
+        HDUtils::BranchDiff.diff_output(
+          command,
+          quiet:         args.quiet?,
+          word_diff:     args.word_diff?,
+          with_stderr:   args.with_stderr?,
+          ignore_errors: args.ignore_errors?,
+          no_api:        args.local?,
+          benchmark:     args.time?,
+        )
+      end
     end
-  end
-
-  def self.branch_compare
-    args = branch_compare_args.parse
-    command = args.named
-
-    ENV.delete("HOMEBREW_INTERNAL_JSON_V3")
-
-    HDUtils::BranchDiff.diff_output(
-      command,
-      quiet:         args.quiet?,
-      word_diff:     args.word_diff?,
-      with_stderr:   args.with_stderr?,
-      ignore_errors: args.ignore_errors?,
-      no_api:        args.local?,
-      benchmark:     args.time?,
-    )
   end
 end

--- a/cmd/generate-api-diff.rb
+++ b/cmd/generate-api-diff.rb
@@ -4,51 +4,50 @@ require "cli/parser"
 require_relative "../lib/hd_utils"
 
 module Homebrew
-  def self.generate_api_diff_args
-    Homebrew::CLI::Parser.new do
-      usage_banner "`generate-api-diff` [<options>]"
-      description <<~EOS
-        Compare the API generation before and and after changes
-        to brew. This helps with debugging and assurance
-        testing when making changes to the JSON API.
+  module Cmd
+    class GenerateApiDiff < AbstractCommand
+      cmd_args do
+        usage_banner "`generate-api-diff` [<options>]"
+        description <<~EOS
+          Compare the API generation before and and after changes
+          to brew. This helps with debugging and assurance
+          testing when making changes to the JSON API.
 
-        Note: One of the `--cask` or `--formula` options is required.
+          Note: One of the `--cask` or `--formula` options is required.
 
-        #{HDUtils::BranchDiff::WARNING_MESSAGE}
-      EOS
+          #{HDUtils::BranchDiff::WARNING_MESSAGE}
+        EOS
 
-      switch "--cask", description: "Run the diff on only core casks."
-      switch "--formula", description: "Run the diff on only core formulae."
-      switch "--word-diff", description: "Show word diff instead of default line diff."
-      switch "--stat", description: "Shows condensed output based on `git diff --stat`"
+        switch "--cask", description: "Run the diff on only core casks."
+        switch "--formula", description: "Run the diff on only core formulae."
+        switch "--word-diff", description: "Show word diff instead of default line diff."
+        switch "--stat", description: "Shows condensed output based on `git diff --stat`"
 
-      conflicts "--word-diff", "--stat"
-
-      conflicts "--cask", "--formula"
-    end
-  end
-
-  def self.generate_api_diff
-    args = generate_api_diff_args.parse
-
-    ENV.delete("HOMEBREW_INTERNAL_JSON_V3")
-
-    command =
-      if args.formula?
-        [HOMEBREW_BREW_FILE, "generate-formula-api"]
-      elsif args.cask?
-        [HOMEBREW_BREW_FILE, "generate-cask-api"]
-      else
-        require "help"
-        Homebrew::Help.help "generate-api-diff"
+        conflicts "--word-diff", "--stat"
+        conflicts "--cask", "--formula"
       end
 
-    HDUtils::BranchDiff.diff_directories(
-      command,
-      quiet:     args.quiet?,
-      word_diff: args.word_diff?,
-      stat:      args.stat?,
-      no_api:    true,
-    )
+      def run
+        ENV.delete("HOMEBREW_INTERNAL_JSON_V3")
+
+        command =
+          if args.formula?
+            [HOMEBREW_BREW_FILE, "generate-formula-api"]
+          elsif args.cask?
+            [HOMEBREW_BREW_FILE, "generate-cask-api"]
+          else
+            require "help"
+            Homebrew::Help.help "generate-api-diff"
+          end
+
+        HDUtils::BranchDiff.diff_directories(
+          command,
+          quiet:     args.quiet?,
+          word_diff: args.word_diff?,
+          stat:      args.stat?,
+          no_api:    true,
+        )
+      end
+    end
   end
 end

--- a/cmd/service-diff.rb
+++ b/cmd/service-diff.rb
@@ -4,52 +4,52 @@ require "cli/parser"
 require_relative "../lib/hd_utils"
 
 module Homebrew
-  def self.service_diff_args
-    Homebrew::CLI::Parser.new do
-      usage_banner "`service-diff` [<options>]"
-      description <<~EOS
-        Compare the service file generation on macOS and Linux before
-        and after changes to brew. This helps with debugging and assurance
-        testing when making changes to the `brew services` DSL.
+  module Cmd
+    class ServiceDiff < AbstractCommand
+      cmd_args do
+        usage_banner "`service-diff` [<options>]"
+        description <<~EOS
+          Compare the service file generation on macOS and Linux before
+          and after changes to brew. This helps with debugging and assurance
+          testing when making changes to the `brew services` DSL.
 
-        #{HDUtils::BranchDiff::WARNING_MESSAGE}
-      EOS
+          #{HDUtils::BranchDiff::WARNING_MESSAGE}
+        EOS
 
-      flag "--formula=", description: "Run the diff on only one formula."
-      flag "--tap=", description: "Run the diff on only one tap."
-      switch "--word-diff", description: "Show word diff instead of default line diff."
-      switch "--stat", description: "Shows condensed output based on `git diff --stat`"
+        flag "--formula=", description: "Run the diff on only one formula."
+        flag "--tap=", description: "Run the diff on only one tap."
+        switch "--word-diff", description: "Show word diff instead of default line diff."
+        switch "--stat", description: "Shows condensed output based on `git diff --stat`"
 
-      conflicts "--tap=", "--formula="
-      conflicts "--word-diff", "--stat"
-    end
-  end
-
-  def self.service_diff
-    args = service_diff_args.parse
-
-    ENV.delete("HOMEBREW_INTERNAL_JSON_V3")
-
-    script_path = File.expand_path("../lib/diff-scripts/service_diff.rb", __dir__)
-    odie "Script #{script_path} doesn't exist!" unless File.exist?(script_path)
-
-    script_args =
-      if args.tap
-        ["tap", args.tap]
-      elsif args.formula
-        ["formula", args.formula]
-      else
-        ["all"]
+        conflicts "--tap=", "--formula="
+        conflicts "--word-diff", "--stat"
       end
 
-    command = [HOMEBREW_BREW_FILE, "ruby", "--", script_path, *script_args]
+      def run
+        ENV.delete("HOMEBREW_INTERNAL_JSON_V3")
 
-    HDUtils::BranchDiff.diff_directories(
-      command,
-      quiet:     args.quiet?,
-      word_diff: args.word_diff?,
-      stat:      args.stat?,
-      no_api:    true,
-    )
+        script_path = File.expand_path("../lib/diff-scripts/service_diff.rb", __dir__)
+        odie "Script #{script_path} doesn't exist!" unless File.exist?(script_path)
+
+        script_args =
+          if args.tap
+            ["tap", args.tap]
+          elsif args.formula
+            ["formula", args.formula]
+          else
+            ["all"]
+          end
+
+        command = [HOMEBREW_BREW_FILE, "ruby", "--", script_path, *script_args]
+
+        HDUtils::BranchDiff.diff_directories(
+          command,
+          quiet:     args.quiet?,
+          word_diff: args.word_diff?,
+          stat:      args.stat?,
+          no_api:    true,
+        )
+      end
+    end
   end
 end

--- a/lib/hd-utils/api-readall/formula_test.rb
+++ b/lib/hd-utils/api-readall/formula_test.rb
@@ -25,11 +25,11 @@ module HDUtils
         end
 
         if error_count.zero?
-          puts "Read core formula and saw no failures!"
+          puts "Read core formulae and saw no failures!"
         else
           Homebrew.failed = true
           noun = (error_count == 1) ? "failure" : "failures"
-          puts "Read core formula and saw #{error_count} #{noun}!"
+          puts "Read core formulae and saw #{error_count} #{noun}!"
 
           unless quiet
             puts


### PR DESCRIPTION
TLDR: The old syntax still works but was deprecated in favor of this new command syntax.

- https://github.com/Homebrew/brew/issues/16814
- https://docs.brew.sh/External-Commands#external-commands-in-taps

Closes #43