### PR TITLE
Remove deprecated `Formula#plist` references

### DIFF
--- a/lib/diff-scripts/service_diff.rb
+++ b/lib/diff-scripts/service_diff.rb
@@ -35,7 +35,7 @@ FORMULAE =
   when "formula"
     [Formulary.factory(COMMAND_ARG)]
   end
-  .select { |f| f.service? || f.plist }
+  .select(&:service?)
   .freeze
 
 FORMULA_FILES = FORMULAE.map(&:path).freeze
@@ -68,14 +68,9 @@ MACOS_DIR.mkdir
 Homebrew::SimulateSystem.with(os: :macos) do
   FORMULA_FILES.each do |formula_file|
     formula = Formulary.factory(formula_file)
+    next unless formula.service.command?
 
-    service_content =
-      if formula.service.command?
-        formula.service.to_plist
-      elsif formula.plist
-        formula.plist
-      end
-
+    service_content = formula.service.to_plist
     next if service_content.nil?
 
     outfile = MACOS_DIR/"#{formula.plist_name}.plist"
@@ -129,14 +124,9 @@ MACOS_API_DIR.mkdir
 Homebrew::SimulateSystem.with(os: :macos) do
   CORE_FORMULAE_NAMES.each do |formula_name|
     formula = Formulary::FromAPILoader.new(formula_name).get_formula(:stable)
+    next unless formula.service.command?
 
-    service_content =
-      if formula.service.command?
-        formula.service.to_plist
-      elsif formula.plist
-        formula.plist
-      end
-
+    service_content = formula.service.to_plist
     next if service_content.nil?
 
     outfile = MACOS_API_DIR/"#{formula.plist_name}.plist"


### PR DESCRIPTION
This was deprecated recently in https://github.com/Homebrew/brew/pull/17233 so it needed to be removed here too. It caused the `rake test:service-diff` command to fail on CI.

See https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/9042900061/job/24849976444