### PR TITLE
Fix cask token error in `brew api-readall-test`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -90,7 +90,7 @@ end
 
 namespace "test" do
   task :"api-readall-test" do
-    cmd "brew", "api-readall-test"
+    cmd "brew", "api-readall-test", "--verbose"
   end
 
   task :"branch-compare" do

--- a/lib/hd-utils/stub-api/cask.rb
+++ b/lib/hd-utils/stub-api/cask.rb
@@ -13,19 +13,19 @@ module HDUtils
     module Cask
       abort "The core cask tap needs to be installed locally to mock the API!" unless CoreCaskTap.instance.installed?
 
-      NAMES = CoreCaskTap.instance.cask_tokens.freeze
-
       print "Generating cask API ..."
 
       # Generate json representation of all casks.
       ::Cask::Cask.generating_hash!
-      JSON = NAMES.to_h do |cask_name|
+      JSON = CoreCaskTap.instance.cask_tokens.to_h do |cask_name|
         cask = ::Cask::CaskLoader.load(cask_name)
         json = JSON.generate(cask.to_hash_with_variations)
         hash = JSON.parse(json)
         [hash["token"], hash.except("token")]
       end.freeze
       ::Cask::Cask.generated_hash!
+
+      NAMES = JSON.keys.freeze
 
       private_constant :NAMES, :JSON
 


### PR DESCRIPTION
```console
$ brew api-readall-test
Generating formulae API ... and mocking formula API loader.
Read core formulae and saw no failures!

Generating cask API ...Warning: Cask font-rounded-mplus was renamed to font-rounded-m+.
 and mocking cask API loader.
Read core casks and saw 1 failure!

Readall Failures: Casks
-----------------------
>> font-rounded-mplus : key not found: "font-rounded-mplus"
/usr/local/Homebrew/Library/Homebrew/cask/cask_loader.rb:318:in `fetch'
```

The problem was that `font-rounded-mplus` got renamed to `font-rounded-m+` and we were getting the cask tokens from the file names instead of the cask definitions directly. I'm not entirely sure why the cask token name from the core cask tap are wrong here but changing the order and basing it on the cask that was loaded seems to work.