### PR TITLE
Fix service-diff command

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ Warning: This command runs git commands on the main brew repo. To be safe avoid
 running other brew commands simultaneously.
 
       --formula                    Run the diff on only one formula.
-      --tap                        Run the diff on only one tap.
       --word-diff                  Show word diff instead of default line diff.
       --stat                       Shows condensed output based on git
                                    diff --stat

--- a/cmd/service-diff.rb
+++ b/cmd/service-diff.rb
@@ -17,11 +17,9 @@ module Homebrew
         EOS
 
         flag "--formula=", description: "Run the diff on only one formula."
-        flag "--tap=", description: "Run the diff on only one tap."
         switch "--word-diff", description: "Show word diff instead of default line diff."
         switch "--stat", description: "Shows condensed output based on `git diff --stat`"
 
-        conflicts "--tap=", "--formula="
         conflicts "--word-diff", "--stat"
       end
 
@@ -32,9 +30,7 @@ module Homebrew
         odie "Script #{script_path} doesn't exist!" unless File.exist?(script_path)
 
         script_args =
-          if args.tap
-            ["tap", args.tap]
-          elsif args.formula
+          if args.formula
             ["formula", args.formula]
           else
             ["all"]

--- a/lib/diff-scripts/service_diff.rb
+++ b/lib/diff-scripts/service_diff.rb
@@ -11,12 +11,11 @@ require "tap"
 # Expects:
 # 1. Command type from VALID_COMMAND_TYPES
 # 2. Command arg
-#    - for command type `tap` it should be the name of a tap
 #    - for command type `formula` it should be the name of a formula
 #    - for command type `all` it is NOT necessary
 COMMAND_TYPE, COMMAND_ARG, *extra = ARGV
 
-VALID_COMMAND_TYPES = %w[all tap formula].freeze
+VALID_COMMAND_TYPES = %w[all formula].freeze
 
 if VALID_COMMAND_TYPES.exclude?(COMMAND_TYPE)
   odie "Unknown command type `#{COMMAND_TYPE}`!"
@@ -29,9 +28,9 @@ end
 FORMULAE =
   case COMMAND_TYPE
   when "all"
-    Formula.all(eval_all: true)
-  when "tap"
-    Tap.fetch(COMMAND_ARG).formula_files.map(&Formulary.method(:factory))
+    CoreTap.instance.formula_names.map do |name|
+      Formulary.factory(name)
+    end
   when "formula"
     [Formulary.factory(COMMAND_ARG)]
   end


### PR DESCRIPTION
The problem here was that for some reason on CI the hashicorp tap is installed and that means that I was running this command for that tap too. This didn't really make any sense because we only really need to run this command for the core tap; nothing else gets serialized to the API.

I removed the --tap= command and now it just runs on the core tap by default which should help us avoid this problem.

I tested it both with all formulae in the core tap and a single formula.

```
>>> Setup
[12](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:13)
git branch test-1728728149 master
[13](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:14)
git switch test-1728728149
[14](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:15)
Switched to branch 'test-1728728149'
[15](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:16)
>>> Test
[16](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:17)
$ brew service-diff --debug
[17](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:18)
Switched to branch 'master'
[18](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:19)
Your branch is up to date with 'origin/master'.
[19](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:20)
/opt/homebrew/Library/Homebrew/formula.rb:319:in `determine_active_spec': hashicorp/tap/vagrant: formula requires at least a URL (FormulaSpecificationError)
[20](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:21)
	from /opt/homebrew/Library/Homebrew/formula.rb:253:in `initialize'
[21](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:22)
	from /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11600/lib/types/private/methods/call_validation.rb:167:in `bind_call'
[22](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:23)
	from /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11600/lib/types/private/methods/call_validation.rb:167:in `validate_call_skip_block_type'
[23](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:24)
	from /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11600/lib/types/private/methods/call_validation.rb:109:in `block in create_validator_slow_skip_block_type'
[24](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:25)
	from /opt/homebrew/Library/Homebrew/formulary.rb:571:in `new'
[25](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:26)
	from /opt/homebrew/Library/Homebrew/formulary.rb:571:in `get_formula'
[26](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:27)
	from /opt/homebrew/Library/Homebrew/formulary.rb:1016:in `factory'
[27](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:28)
	from /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11600/lib/types/private/methods/call_validation.rb:167:in `bind_call'
[28](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:29)
	from /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11600/lib/types/private/methods/call_validation.rb:167:in `validate_call_skip_block_type'
[29](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:30)
	from /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11600/lib/types/private/methods/call_validation.rb:109:in `block in create_validator_slow_skip_block_type'
[30](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:31)
	from /opt/homebrew/Library/Homebrew/formula.rb:2143:in `block in all'
[31](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:32)
	from /opt/homebrew/Library/Homebrew/formula.rb:2142:in `each'
[32](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:33)
	from /opt/homebrew/Library/Homebrew/formula.rb:2142:in `filter_map'
[33](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:34)
	from /opt/homebrew/Library/Homebrew/formula.rb:2142:in `all'
[34](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:35)
	from /Users/runner/work/homebrew-dev-utils/homebrew-dev-utils/lib/diff-scripts/service_diff.rb:32:in `<main>'
[35](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:36)
Error: failure on master branch
[36](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:37)
Error: failure on master branch
[37](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:38)
Error: Kernel.exit
[38](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:39)
Error: Kernel.exit
[39](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:40)
Warning: Removed Sorbet lines from backtrace!
[40](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:41)
Warning: Removed Sorbet lines from backtrace!
[41](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:42)
/opt/homebrew/Library/Homebrew/extend/kernel.rb:102:in `exit'
[42](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:43)
/opt/homebrew/Library/Homebrew/extend/kernel.rb:102:in `odie'
[43](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:44)
/Users/runner/work/homebrew-dev-utils/homebrew-dev-utils/lib/hd-utils/branch_diff.rb:117:in `block (3 levels) in diff_directories'
[44](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:45)
/Users/runner/work/homebrew-dev-utils/homebrew-dev-utils/lib/hd-utils/branch_diff.rb:116:in `chdir'
[45](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:46)
/Users/runner/work/homebrew-dev-utils/homebrew-dev-utils/lib/hd-utils/branch_diff.rb:116:in `block (2 levels) in diff_directories'
[46](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:47)
/Users/runner/work/homebrew-dev-utils/homebrew-dev-utils/lib/hd-utils/branch_diff.rb:110:in `map'
[47](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:48)
/Users/runner/work/homebrew-dev-utils/homebrew-dev-utils/lib/hd-utils/branch_diff.rb:110:in `block in diff_directories'
[48](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:49)
/Users/runner/work/homebrew-dev-utils/homebrew-dev-utils/lib/hd-utils/branch_diff.rb:97:in `chdir'
[49](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:50)
/Users/runner/work/homebrew-dev-utils/homebrew-dev-utils/lib/hd-utils/branch_diff.rb:97:in `diff_directories'
[50](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:51)
/opt/homebrew/Library/Taps/apainintheneck/homebrew-dev-utils/cmd/service-diff.rb:45:in `run'
[51](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:52)
/opt/homebrew/Library/Homebrew/brew.rb:94:in `<main>'
[52](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:53)
>>> Cleanup
[53](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:54)
git switch master
[54](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:55)
Switched to branch 'master'
[55](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:56)
Your branch is up to date with 'origin/master'.
[56](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:57)
git branch -D test-1728728149
[57](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:58)
Deleted branch test-1728728149 (was 3291ad4fc7).
[58](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:59)
rake aborted!
[59](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:60)
Command failed with status (1): [brew service-diff --debug]
[60](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:61)
/Users/runner/work/homebrew-dev-utils/homebrew-dev-utils/Rakefile:13:in `cmd'
[61](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:62)
/Users/runner/work/homebrew-dev-utils/homebrew-dev-utils/Rakefile:111:in `block (3 levels) in <top (required)>'
[62](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:63)
/Users/runner/work/homebrew-dev-utils/homebrew-dev-utils/Rakefile:42:in `block in with_test_branch'
[63](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:64)
/Users/runner/work/homebrew-dev-utils/homebrew-dev-utils/Rakefile:20:in `chdir'
[64](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:65)
/Users/runner/work/homebrew-dev-utils/homebrew-dev-utils/Rakefile:20:in `with_test_branch'
[65](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:66)
/Users/runner/work/homebrew-dev-utils/homebrew-dev-utils/Rakefile:110:in `block (2 levels) in <top (required)>'
[66](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:67)
Tasks: TOP => test:service-diff
[67](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:68)
(See full trace by running task with --trace)
[68](https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658#step:8:69)
Error: Process completed with exit code 1.
```

- https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/11304816448/job/31443644658